### PR TITLE
Spring Security Exception 발생시 Exception Handler를 탈 수 있도록 구현

### DIFF
--- a/src/course/rest/http-client.env.json
+++ b/src/course/rest/http-client.env.json
@@ -1,6 +1,6 @@
 {
   "dev": {
-    "host": "http://ec2-52-78-18-217.ap-northeast-2.compute.amazonaws.com/api",
+    "host": "mannal.ga/api",
     "token-sdm" : "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDM5NTI4NTk3Iiwic3ViIjoiMTQzOTUyODU5NyIsImlhdCI6MTYxNzI1MjE5MSwiZXhwIjoxNjQ4Nzg4MTkxfQ.mCDTjD_3dQqTyaM3OggRHGD7eY3Vv6Ud6JpfD7qlf2E",
     "token-jun" : "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDUxMDAxNjQ5Iiwic3ViIjoiMTQ1MTAwMTY0OSIsImlhdCI6MTU5OTI4MzIxOCwiZXhwIjoxNjMwODE5MjE4fQ.v-sfReNKli476qoHc1F2yoak-n4bh_D2Db5rczwS3Bs",
     "token-dong": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOiIxNDEyMzc1MzA5Iiwic3ViIjoiMTQxMjM3NTMwOSIsImlhdCI6MTYwMDQ0MDc4OSwiZXhwIjoxNjMxOTc2Nzg5fQ.csOA38Zh0dL1OtG0AKqRudY4E8FQMg3gVC80h7XuPsY",

--- a/src/main/kotlin/com/taskforce/superinvention/common/advice/GlobalAdviceController.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/advice/GlobalAdviceController.kt
@@ -1,6 +1,8 @@
 package com.taskforce.superinvention.common.advice
 
 import com.taskforce.superinvention.common.exception.BizException
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.JwtException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -58,4 +60,10 @@ class GlobalAdviceController {
 
         return ResponseEntity(ErrorResponse(errorMessage), HttpStatus.BAD_REQUEST)
     }
+
+    @ExceptionHandler(ExpiredJwtException::class)
+    fun handleExpiredJwtException(e: Exception): ResponseEntity<ErrorResponse> = ResponseEntity(ErrorResponse("JWT 토큰이 만료되었습니다."), HttpStatus.UNAUTHORIZED)
+
+    @ExceptionHandler(JwtException::class)
+    fun handleJwtException(e: Exception): ResponseEntity<ErrorResponse> = ResponseEntity(ErrorResponse("JWT 토큰이 유효하지 않습니다"), HttpStatus.UNAUTHORIZED)
 }

--- a/src/main/kotlin/com/taskforce/superinvention/common/config/security/FilterChainExceptionHandler.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/config/security/FilterChainExceptionHandler.kt
@@ -1,0 +1,32 @@
+package com.taskforce.superinvention.common.config.security
+
+import org.springframework.web.filter.OncePerRequestFilter
+import java.lang.Exception
+import javax.servlet.FilterChain
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+import org.springframework.web.servlet.HandlerExceptionResolver
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+
+@Component
+class FilterChainExceptionHandler : OncePerRequestFilter() {
+
+    @Autowired
+    @Qualifier("handlerExceptionResolver")
+    lateinit var resolver: HandlerExceptionResolver
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (e: Exception) {
+            resolver.resolveException(request, response, null, e)
+        }
+    }
+}

--- a/src/main/kotlin/com/taskforce/superinvention/common/config/security/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/config/security/JwtTokenProvider.kt
@@ -54,16 +54,11 @@ class JwtTokenProvider(
     }
 
     fun validateToken(token: String?): Boolean {
-        return try {
-            Jwts.parser()
-                .setSigningKey(secretKey.toByteArray())
-                .parseClaimsJws(token)
-            true
-        } catch (e: ExpiredJwtException) {
-            throw BizException("JWT 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED)
-        } catch (e: JwtException) {
-            throw BizException("잘못된 JWT 토큰입니다.", HttpStatus.UNAUTHORIZED)
-        }
+        Jwts.parser()
+            .setSigningKey(secretKey.toByteArray())
+            .parseClaimsJws(token)
+
+        return  true
     }
 
     private fun getUserId(token: String): String {

--- a/src/main/kotlin/com/taskforce/superinvention/common/config/security/WebSecurityConfig.kt
+++ b/src/main/kotlin/com/taskforce/superinvention/common/config/security/WebSecurityConfig.kt
@@ -11,12 +11,15 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 
 import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.authentication.logout.LogoutFilter
 
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled=true, securedEnabled = true)
 class WebSecurityConfig(
-    private val jwtTokenProvider: JwtTokenProvider
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val filterChainExceptionHandler: FilterChainExceptionHandler,
 ): WebSecurityConfigurerAdapter() {
+
 
     @Bean
     fun passwordEncoder(): PasswordEncoder {
@@ -49,7 +52,9 @@ class WebSecurityConfig(
 
         // [4] entry point
         http.authorizeRequests()
-            .anyRequest()
-            .permitAll()
+                .anyRequest()
+                .permitAll()
+            .and()
+            .addFilterBefore(filterChainExceptionHandler, LogoutFilter::class.java)
     }
 }


### PR DESCRIPTION
#400 
JWT 토큰의 인증/인가에 문제가 생겼을 경우, Spring Securty의 Filter chain단에서 Exception이 발생하기 때문에 GlobalExceptionHandler가 작동하지 않음.

그래서 필터를 추가하여 글로벌 별도의 HandlerExceptionResolver를 타도록 설정 추가. 시큐리티 설정에도 LogoutFilter 이전에 해당 커스텀 필터를 한번 더 타도록 만들어서 익셉션핸들링 진행.